### PR TITLE
Allow for wires to display colors as LIFO when stepping back

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -25,6 +25,10 @@ const wireState = ref({
   cycle: 0,
   macro: undefined as string | undefined,
 });
+/**
+ * Track activation history for each wire to enable stack-like color behavior
+ */
+const wireActivationHistory = ref<Map<string, number[]>>(new Map());
 const loopId = ref<number>();
 const running = computed(() => typeof loopId.value !== "undefined");
 const isLoopDone = computed(() => wireState.value.step >= wireState.value.wires.length);
@@ -40,7 +44,6 @@ function handleKeydown(event: KeyboardEvent) {
     (document.activeElement as HTMLElement)?.blur();
   }
 
-  // If not focused on anything
   if (document.activeElement == document.body || document.activeElement == document.documentElement) {
     if (event.code === 'ArrowLeft') {
       // On left, step back
@@ -74,7 +77,18 @@ function stepBack() {
   if (wire == CYCLE_BREAK) {
     wireState.value.cycle--;
   } else {
-    lc3Diagram.value?.deactivateWire(wire);
+    const history = wireActivationHistory.value.get(wire) || [];
+    if (history.length > 0) {
+      history.pop(); 
+      
+      if (history.length > 0) {
+        const previousCycle = history[history.length - 1];
+        lc3Diagram.value?.activateWire(wire, previousCycle);
+      } else {
+        lc3Diagram.value?.deactivateWire(wire);
+        wireActivationHistory.value.delete(wire);
+      }
+    }
   }
 }
 function stepFwd() {
@@ -86,6 +100,12 @@ function stepFwd() {
   if (wire == CYCLE_BREAK) {
     wireState.value.cycle++;
   } else {
+    // Track this activation in the history
+    if (!wireActivationHistory.value.has(wire)) {
+      wireActivationHistory.value.set(wire, []);
+    }
+    wireActivationHistory.value.get(wire)!.push(wireState.value.cycle);
+    
     lc3Diagram.value?.activateWire(wire, wireState.value.cycle);
   }
   wireState.value.step++;
@@ -147,6 +167,9 @@ function resetDiagramLoop() {
       cycle: 0,
       macro: undefined
     };
+    
+    // Clear the activation history
+    wireActivationHistory.value.clear();
 }
 function toggleDiagramLoop() {
   if (running.value) {


### PR DESCRIPTION
When stepping back, the wire would return to white even when there was a previous color before it